### PR TITLE
fix(clients): correct getting by mac

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,7 @@
 import createDebug, { Debugger } from 'debug';
 import url, { URL, URLSearchParams } from 'url';
 import { AxiosInstance, RawAxiosRequestConfig } from 'axios';
-import { dateInput } from './commons/types';
+import type { dateInput } from './commons';
 import { Validate } from './commons/Validate';
 import type { Controller } from './Controller';
 import semver from 'semver';
@@ -110,4 +110,18 @@ export const checkNeedVersion = (controller: Controller, minVersion?: string, un
     }
 
     throw new ClientError(str, code);
+};
+
+export const formatMacAddress = (macAddress: string, separator: string): string => {
+    const macAddressRegex = /^([0-9A-F]{2}[:-]?){5}([0-9A-F]{2})$/i;
+
+    if (!macAddressRegex.test(macAddress)) {
+        throw new Error('"macAddress" is not a valid MAC address');
+    }
+
+    const mac = macAddress.replace(/[:-]/g, '');
+
+    return Array.from({ length: mac.length / 2 }, (_, i) => i)
+        .map((i) => mac.slice(i * 2, i * 2 + 2))
+        .join(separator);
 };

--- a/tests/units/Clients.test.ts
+++ b/tests/units/Clients.test.ts
@@ -145,7 +145,7 @@ describe('Clients', () => {
             mockedAxios.get.mockImplementationOnce(() => Promise.resolve({ data: { data: [client] } }));
             await clients.getByMac(macAddress);
 
-            expect(mockedAxios.get).toHaveBeenCalledWith('/stat/sta/:mac', { urlParams: { mac: macAddress } });
+            expect(mockedAxios.get).toHaveBeenCalledWith(`/stat/sta/${macAddress}`);
             expect(mapObjectMock).toHaveBeenCalledWith(Client, client);
         });
 
@@ -154,7 +154,7 @@ describe('Clients', () => {
             mockedAxios.get.mockImplementationOnce(() => Promise.resolve({}));
             await clients.getByMac(macAddress);
 
-            expect(mockedAxios.get).toHaveBeenCalledWith('/stat/sta/:mac', { urlParams: { mac: macAddress } });
+            expect(mockedAxios.get).toHaveBeenCalledWith(`/stat/sta/${macAddress}`);
             expect(mapObjectMock).not.toHaveBeenCalled();
         });
     });

--- a/tests/units/util.test.ts
+++ b/tests/units/util.test.ts
@@ -1,4 +1,11 @@
-import { axiosUrlParams, convertTimestampSecondsToDate, createDebugger, getUrlRepresentation, removeTrailingSlash } from '../../src/util';
+import {
+    axiosUrlParams,
+    convertTimestampSecondsToDate,
+    createDebugger,
+    getUrlRepresentation,
+    removeTrailingSlash,
+    formatMacAddress
+} from '../../src/util';
 import { AxiosInstance } from 'axios';
 
 describe('utils tests', () => {
@@ -209,6 +216,24 @@ describe('utils tests', () => {
         });
         it('should build from other than timestamp', () => {
             expect(convertTimestampSecondsToDate('2020-06-30T22:41:14.000Z')).toStrictEqual(new Date('2020-06-30T22:41:14.000Z'));
+        });
+    });
+
+    describe('formatMacAddress', () => {
+        const macAddresses = ['00:14:22:01:23:45', '00-14-22-01-23-45', '001422012345'];
+
+        describe.each([
+            ['-', '00-14-22-01-23-45'],
+            [':', '00:14:22:01:23:45'],
+            ['', '001422012345']
+        ])('with separator %s and expected result %s', (separator, expectedResult) => {
+            it.each(macAddresses)('should format MAC address %s', (macAddress) => {
+                expect(formatMacAddress(macAddress, separator)).toBe(expectedResult);
+            });
+        });
+
+        it('should throw an error for invalid MAC addresses', () => {
+            expect(() => formatMacAddress('invalid_mac', ':')).toThrow('"macAddress" is not a valid MAC address');
         });
     });
 });


### PR DESCRIPTION
## :memo: Description

GetByMac doesn't works, because unifi doesn't support urlEncoded part in url ( not mandatory for : )

### :dart: Relevant issues

Fix #646 

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## :vertical_traffic_light: How Has This Been Tested?

- [X] Unit
- [X] Manual

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
