### PR TITLE
fix(axios-error): replace old dependency throwing security error with a fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
       "dependencies": {
         "axios": "1.6.1",
         "axios-curlirize": "1.3.7",
-        "axios-error": "1.0.4",
         "cookie": "0.6.0",
         "debug": "4.3.4",
         "jsonwebtoken": "9.0.2",
@@ -1845,24 +1844,6 @@
     "node_modules/axios-curlirize": {
       "version": "1.3.7",
       "license": "MIT"
-    },
-    "node_modules/axios-error": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^0.21.1",
-        "type-fest": "^0.15.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/axios-error/node_modules/axios": {
-      "version": "0.21.4",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -5658,16 +5639,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "0.15.1",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typedoc": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   "dependencies": {
     "axios": "1.6.1",
     "axios-curlirize": "1.3.7",
-    "axios-error": "1.0.4",
     "cookie": "0.6.0",
     "debug": "4.3.4",
     "jsonwebtoken": "9.0.2",

--- a/src/Controller.ts
+++ b/src/Controller.ts
@@ -10,12 +10,12 @@ import { ObjectWithPrivateValues } from './commons/ObjectWithPrivateValues';
 import { Validate } from './commons/Validate';
 import { UnifiWebsockets } from './WebSockets';
 import { EventEmitter } from 'events';
-import AxiosError from 'axios-error';
 import { Site, Sites } from './Sites';
 import { IUser } from './User';
 import { EProxyNamespaces, IBuildUrlParams, proxyNamespace } from './interfaces';
 import { DeviceFingerPrints, FingerprintsRaw } from './Clients';
 import { IControllerProps } from './IControllerProps';
+import { AxiosError } from './Errors/AxiosError';
 
 const axiosDebug = createDebugger('axios');
 const axiosDebugVerbose = axiosDebug.extend('verbose');

--- a/src/Errors/AxiosError.ts
+++ b/src/Errors/AxiosError.ts
@@ -1,0 +1,128 @@
+import * as util from 'util';
+import { AxiosError as BaseAxiosError } from 'axios';
+
+//fork of axios-error https://github.com/bottenderjs/messaging-apis/blob/master/packages/axios-error/src/index.ts
+
+function indent(str: string): string {
+    return (str || '')
+        .split('\n')
+        .map((s) => (s ? `  ${s}` : ''))
+        .join('\n');
+}
+
+function json(data: unknown): string {
+    try {
+        return JSON.stringify(data, null, 2);
+    } catch (e) {
+        return '<json-unstringifiable>';
+    }
+}
+
+export type customPickFromAxiosError = Pick<BaseAxiosError, 'config' | 'request' | 'response'>;
+
+export class AxiosError extends Error {
+    config: BaseAxiosError['config'];
+
+    request?: BaseAxiosError['request'];
+
+    response?: BaseAxiosError['response'];
+
+    status?: number;
+
+    /**
+     * @example
+     * ```js
+     * new AxiosError(errorThrownByAxios)
+     * ```
+     */
+    constructor(error: BaseAxiosError);
+
+    /**
+     * @example
+     * ```js
+     * new AxiosError('error message', errorThrownByAxios)
+     * ```
+     */
+    constructor(message: string, error: BaseAxiosError);
+
+    /**
+     * @example
+     * ```js
+     * new AxiosError('error message', { config, request, response })
+     * ```
+     */
+    constructor(message: string, error: customPickFromAxiosError);
+
+    constructor(messageOrError: string | BaseAxiosError, error?: BaseAxiosError | customPickFromAxiosError) {
+        let err: customPickFromAxiosError;
+        if (typeof messageOrError === 'string') {
+            super(messageOrError);
+            err = error as customPickFromAxiosError;
+        } else {
+            super(messageOrError.message);
+            err = messageOrError;
+        }
+
+        const { config, request, response } = err;
+
+        this.config = config;
+        this.request = request;
+        this.response = response;
+        if (response?.status) {
+            this.status = response.status;
+        }
+
+        this.name = 'AxiosError';
+    }
+
+    [util.inspect.custom](): string {
+        let requestMessage = '';
+
+        if (this.config) {
+            let { data } = this.config;
+
+            try {
+                data = JSON.parse(data);
+            } catch (_) {} // eslint-disable-line
+
+            let requestData = '';
+
+            if (this.config.data) {
+                requestData = `
+Request Data -
+${indent(json(data))}`;
+            }
+
+            requestMessage = `
+Request -
+  ${this.config.method ? this.config.method.toUpperCase() : ''} ${this.config.url}
+${requestData}`;
+        }
+
+        let responseMessage = '';
+
+        if (this.response) {
+            let responseData = '';
+
+            if (this.response.data) {
+                responseData = `
+Response Data -
+${indent(json(this.response.data))}`;
+            }
+
+            responseMessage = `
+Response -
+  ${this.response.status} ${this.response.statusText}
+${responseData}`;
+        }
+
+        return `
+${this.stack}
+
+Error Message -
+  ${this.message}
+${requestMessage}
+${responseMessage}
+`;
+    }
+}

--- a/src/Errors/UnifiError.ts
+++ b/src/Errors/UnifiError.ts
@@ -1,5 +1,5 @@
 import { __Error } from './__Error';
-import AxiosError from 'axios-error';
+import { AxiosError } from './AxiosError';
 
 export interface IUnifiErrorMeta {
     msg?: string;
@@ -15,7 +15,7 @@ export class UnifiError extends __Error {
 
     public constructor(message: string | Error = '', code = 0, pMeta: IUnifiErrorMeta = {}, exception?: AxiosError) {
         super(message, code, exception);
-        //clone meta object before removing parts
+        //clone "meta" object before removing parts
         const meta = { ...pMeta };
 
         //just in case


### PR DESCRIPTION
## :memo: Description

the dependency `axios-error` (that will pretty print the axios errors), is not updated from a long time, and so come with an old `axios` version, triggering (false[^1]) security alerts

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :vertical_traffic_light: How Has This Been Tested?

I'm using this class on another project

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas

[^1]: this version of axios is not used, just installed by axios-error (only for typing)